### PR TITLE
preventing passphrase from beeing leaked by process listing

### DIFF
--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -12,7 +12,7 @@ module DMCrypt
     end
 
     def self.create_device_passphrase(passphrase, device)
-      shell_out!("printf \"%s\\n\" #{passphrase} #{passphrase} | cryptsetup -q luksFormat #{device}") # rubocop:disable Metrics/LineLength
+      shell_out!("cryptsetup luksFormat #{device} -", input: passphrase)
     end
 
     def self.encrypted?(device)


### PR DESCRIPTION
Passing the passphrase to a commandline tool as an argument can lead to problems on multiuser systems as it might show up in the process listing of other users. I wasn't able to run the tests due to a lack of diskspace so far but will try to do so later.